### PR TITLE
fix `implied_bounds_entailment` future compatibility lint

### DIFF
--- a/src/ds/sequence.rs
+++ b/src/ds/sequence.rs
@@ -133,7 +133,7 @@ where
 {
     type Output = Idx::Output;
 
-    fn index(&self, index: Idx) -> &'a Self::Output {
+    fn index(&self, index: Idx) -> &Self::Output {
         &self.chain[index]
     }
 }


### PR DESCRIPTION
Your crate unintentionally relied on a soundness bug in the Rust compiler, see https://github.com/rust-lang/rust/issues/105572 for more info. This lint will be a hard error in a future release. This PR fixes that lint.